### PR TITLE
Add the missing methods to play nice with _big.json.builder

### DIFF
--- a/app/models/spree/conekta_oxxo_payment.rb
+++ b/app/models/spree/conekta_oxxo_payment.rb
@@ -42,6 +42,14 @@ module Spree
       %w(void)
     end
 
+    def gateway_customer_profile_id
+      user_id
+    end
+
+    def gateway_payment_profile_id
+      id
+    end
+
     private
     def payload(order)
       {


### PR DESCRIPTION
Add the gateway_customer_profile_id and gateway_payment_profile_id methods to the conekta_oxxo_payment