### PR TITLE
Update payment method partial name convention

### DIFF
--- a/app/views/spree/admin/payments/source_forms/_conekta_oxxo.html.erb
+++ b/app/views/spree/admin/payments/source_forms/_conekta_oxxo.html.erb
@@ -1,0 +1,12 @@
+<fieldset>
+  <legend align="center">Oxxo Pay</legend>
+  <div class="opps-info text-center">
+    <div class="opps-brand">
+      <%= image_tag 'oxxopay_brand.png', alt: 'OXXOPay' %>
+    </div>
+    <% param_prefix = "payment_source[#{payment_method.id}]" %>
+    <%= hidden_field_tag "#{param_prefix}[first_name]", @order.ship_address&.first_name %>
+    <%= hidden_field_tag "#{param_prefix}[last_name]", @order.ship_address&.last_name %>
+    <%= hidden_field_tag "#{param_prefix}[number]", @order.number %>
+  </div>
+</fieldset>

--- a/app/views/spree/admin/payments/source_views/_conekta_oxxo.html.erb
+++ b/app/views/spree/admin/payments/source_views/_conekta_oxxo.html.erb
@@ -1,0 +1,13 @@
+<fieldset>
+  <legend align="center">Oxxo Pay</legend>
+  <div class="opps-info text-center">
+    <div class="opps-brand">
+      <%= image_tag 'oxxopay_brand.png', alt: 'OXXOPay' %>
+    </div>
+  </div>
+  <div class="opps-reference">
+    <h3>Referencia</h3>
+    <h1><%= payment.response_code.to_s.scan(/.{1,4}/).join('-') %></h1>
+  </div>
+  <%= link_to t('payment.print_ticket'), oxxo_pay_receipt_path(id: payment.id), target: 'new', class: 'eyecatcher-link__text' %>
+</fieldset>

--- a/app/views/spree/api/source_views/_conekta_oxxo.json.jbuilder
+++ b/app/views/spree/api/source_views/_conekta_oxxo.json.jbuilder
@@ -1,0 +1,1 @@
+# frozen_string_literal: true

--- a/app/views/spree/checkout/payment/_conekta_oxxo.html.erb
+++ b/app/views/spree/checkout/payment/_conekta_oxxo.html.erb
@@ -1,0 +1,11 @@
+<div class="row">
+  <div class="twelve rows alpha omega center">
+    <div class="payment-label-title">Oxxo Pay</div>
+    <p class="payment-label-description">Al completar tu compra se te entregará un número de referencia para que puedas
+    pagar en tu tienda Oxxo más cercana</p>
+    <% param_prefix = "payment_source[#{payment_method.id}]" %>
+    <%= hidden_field_tag "#{param_prefix}[first_name]", current_order.ship_address&.first_name %>
+    <%= hidden_field_tag "#{param_prefix}[last_name]", current_order.ship_address&.last_name %>
+    <%= hidden_field_tag "#{param_prefix}[number]", current_order&.number %>
+  </div>
+</div>

--- a/app/views/spree/checkout/payment_label/_conekta_oxxo_label.html.erb
+++ b/app/views/spree/checkout/payment_label/_conekta_oxxo_label.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <div class="payment-label">Oxxo pay</div>
+</div>

--- a/solidus_oxxo_pay.gemspec
+++ b/solidus_oxxo_pay.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop-rspec', '1.4.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3', '~> 1.3.6'
+  s.add_development_dependency 'selenium-webdriver'
 end


### PR DESCRIPTION
## Summary
In recent version of Solidus (starting 2.9) the payment method naming convention changed, see: https://github.com/solidusio/solidus/pull/3217